### PR TITLE
Assistant checkpoint: Update project structure for Vercel deployment

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'standalone',
   reactStrictMode: true,
   swcMinify: true,
   eslint: {

--- a/package.json
+++ b/package.json
@@ -1,3 +1,4 @@
+
 {
   "name": "next-jampack-classic",
   "version": "1.0.1",
@@ -37,15 +38,15 @@
     "lightgallery": "^2.8.1",
     "moment": "^2.30.1",
     "nanoid": "^5.0.8",
-    "next": "^15.0.3",
+    "next": "^15.1.7",
     "next-seo": "^6.6.0",
     "prop-types": "^15.8.1",
-    "react": "^18",
+    "react": "^18.2.0",
     "react-apexcharts": "^1.5.0",
     "react-bootstrap": "^2.10.5",
     "react-bootstrap-daterangepicker": "^8.0.0",
     "react-datepicker": "^7.5.0",
-    "react-dom": "^18",
+    "react-dom": "^18.2.0",
     "react-feather": "^2.0.10",
     "react-notifications-component": "^4.0.1",
     "react-perfect-scrollbar": "^1.5.8",

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,4 @@
 
 {
-  "projects": {
-    "default": {
-      "source": "src"
-    }
-  }
+  "rootDirectory": "src"
 }


### PR DESCRIPTION
Assistant generated file changes:
- package.json: Move package.json to root with Next.js dependencies
- next.config.js: Update Next.js configuration
- vercel.json: Update Vercel configuration

---

User prompt:

Listo. El error indica que Vercel no detecta Next.js como dependencia, y también está ejecutando el build en la raíz, pero tu proyecto está dentro de src/.

Aquí tienes el prompt actualizado y completo para que lo copies y pegues en Replit AI:

⸻

Prompt para Replit AI:

Por favor, realiza los siguientes ajustes para que el proyecto sea 100% compatible con el despliegue automático en Vercel desde la rama main. La aplicación está dentro del directorio src:
	1.	Mover package.json y next.config.js a la raíz del proyecto si actualmente están dentro de src/, o si los archivos están solo en src/, entonces: •	Crea un package.json en la raíz que tenga:

{
  "private": true,
  "workspaces": ["src"]
}

	•	O simplemente mueve el contenido completo del frontend de src a la raíz si no es un monorepo.

	2.	Asegúrate de que Next.js esté instalado como dependencia en el package.json, así:

{
  "dependencies": {
    "next": "^15.1.7", "react": "^18.2.0", "react-dom": "^18.2.0" } }

	3.	Crea un archivo next.config.js en la raíz con este contenido:

/** @type {import('next').NextConfig} */
const nextConfig = {
  output: 'standalone'
};
module.exports = nextConfig;

	4.	Crea un archivo vercel.json en la raíz con esta configuración si vas a mantener todo en src/:

{
  "rootDirectory": "src"
}

	5.	Asegúrate de que exista una página válida en: •	src/pages/index.tsx (si usas Pages Router), o •	src/app/page.tsx y src/app/layout.tsx (si usas App Router).
	6.	Verifica que el script de build esté presente:

"scripts": {
  "build": "next build"
}

⸻

Replit-Commit-Author: Assistant
Replit-Commit-Session-Id: fc426248-7f8f-43da-b7a1-bf0eb27348ec